### PR TITLE
fog: Switch to common light HAL

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -257,7 +257,7 @@ PRODUCT_PACKAGES += \
 
 # Lights
 PRODUCT_PACKAGES += \
-    android.hardware.light-service.xiaomi
+    android.hardware.light-service.lineage
 
 # Media
 PRODUCT_PACKAGES += \

--- a/sepolicy/vendor/file_contexts
+++ b/sepolicy/vendor/file_contexts
@@ -62,9 +62,6 @@
 # Label discard_max_bytes in /data partition
 /sys/devices/platform/soc/4804000.ufshc/host0/target0:0:0/0:0:0:0/block/sda/queue/discard_max_bytes                                                 u:object_r:vendor_sysfs_scsi_host:s0
 
-# Lights
-/vendor/bin/hw/android\.hardware\.light-service\.xiaomi                 u:object_r:hal_light_default_exec:s0
-
 # NFC
 /vendor/bin/STFlashTool                                                 u:object_r:stflashtool_exec:s0
 /vendor/bin/hw/android\.hardware\.nfc@1\.2-service\.st                  u:object_r:hal_nfc_default_exec:s0


### PR DESCRIPTION
Lineage has switched to common light HAL. Xiaomi light HAL was also removed completely from lineage, resulting in errors during a build.